### PR TITLE
Updated dependencies

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,8 +1,13 @@
-{:paths ["src"]
- :deps {org.clojure/clojure {:mvn/version "1.10.0-RC1"},
-        org.apache.jena/apache-jena-libs {:mvn/version "3.4.0", :extension "pom"}}
- :aliases {:run-tests {:main-opts ["-m" "cognitect.test-runner"]}
-           :test {:extra-paths ["test"]
-                  :extra-deps {com.cognitect/test-runner {:git/url "git@github.com:cognitect-labs/test-runner"
-                                                          :sha "5fb4fc46ad0bf2e0ce45eba5b9117a2e89166479"}
-                               ch.qos.logback/logback-classic {:mvn/version "1.2.3"}}}}}
+{:paths   ["src"]
+ :deps    {org.clojure/clojure              {:mvn/version "1.10.3"}
+           org.apache.jena/apache-jena-libs {:mvn/version "3.14.0"
+                                             :extension   "pom"}
+
+           ;; Adds missing javax.xml.bind.DatatypeConverter in Java 9+
+           javax.xml.bind/jaxb-api          {:mvn/version "2.4.0-b180830.0359"}}
+ :aliases {:test {:extra-paths ["test"]
+                  :extra-deps  {io.github.cognitect-labs/test-runner {:git/url "https://github.com/cognitect-labs/test-runner.git"
+                                                                      :sha     "62ef1de18e076903374306060ac0e8a752e57c86"}
+                                ch.qos.logback/logback-classic       {:mvn/version "1.2.3"}}
+                  :main-opts   ["-m" "cognitect.test-runner"]
+                  :exec-fn     cognitect.test-runner.api/test}}}


### PR DESCRIPTION
- most recent stable version of Clojure 1.10.3
- Jena 3.14.4 (same as ont-app/igraph)
- latest test-runner (fix dependency resolution)
- use test-runner example code as template (run with: clj -X:test)
- added javax.xml.bind/jaxb-api (fix builds on later JVM versions)

These changes should make the project work better on later later versions of the JVM, later versions of the Clojure CLI, as well as ensuring peaceful coexistence with [igraph-jena](https://github.com/ont-app/igraph-jena).

Tests are now run using `clj -X:test` which I lifted from the [example code](https://github.com/cognitect-labs/test-runner#invoke-with-clojure--x-exec-style) provided by Alex Miller.