### PR TITLE
RDF langString support

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -2,6 +2,7 @@
  :deps    {org.clojure/clojure              {:mvn/version "1.10.3"}
            org.apache.jena/apache-jena-libs {:mvn/version "3.14.0"
                                              :extension   "pom"}
+           ont-app/vocabulary               {:mvn/version "0.1.3"}
 
            ;; Adds missing javax.xml.bind.DatatypeConverter in Java 9+
            javax.xml.bind/jaxb-api          {:mvn/version "2.4.0-b180830.0359"}}


### PR DESCRIPTION
This PR adds support for RDF langStrings using Eric D. Scott's [vocabulary](https://github.com/ont-app/vocabulary) library.

At the moment, Aristotle quietly loses language information in its query results. When querying multilingual resources, e.g. [Ontolex](http://www.w3.org/ns/lemon/ontolex#), this results in collections of strings being returned with no way of distinguishing between the returned strings based on language.

This PR simply returns the `LangStr` type instead of regular strings when this is the case and accepts `LangStr` as input data too.