### PR TITLE
Update to Apache Jena 4.5

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,14 +1,13 @@
 {:paths   ["src"]
- :deps    {org.clojure/clojure              {:mvn/version "1.10.3"}
-           org.apache.jena/apache-jena-libs {:mvn/version "3.14.0"
+ :deps    {org.clojure/clojure              {:mvn/version "1.11.1"}
+           org.apache.jena/apache-jena-libs {:mvn/version "4.5.0"
                                              :extension   "pom"}
-           ont-app/vocabulary               {:mvn/version "0.1.3"}
+           ont-app/vocabulary               {:mvn/version "0.1.7"}
 
            ;; Adds missing javax.xml.bind.DatatypeConverter in Java 9+
            javax.xml.bind/jaxb-api          {:mvn/version "2.4.0-b180830.0359"}}
  :aliases {:test {:extra-paths ["test"]
-                  :extra-deps  {io.github.cognitect-labs/test-runner {:git/url "https://github.com/cognitect-labs/test-runner.git"
-                                                                      :sha     "62ef1de18e076903374306060ac0e8a752e57c86"}
-                                ch.qos.logback/logback-classic       {:mvn/version "1.2.3"}}
+                  :extra-deps  {io.github.cognitect-labs/test-runner {:git/tag "v0.5.1" :git/sha "dfb30dd"}
+                                ch.qos.logback/logback-classic       {:mvn/version "1.2.11"}}
                   :main-opts   ["-m" "cognitect.test-runner"]
                   :exec-fn     cognitect.test-runner.api/test}}}

--- a/test/arachne/aristotle/graph_test.clj
+++ b/test/arachne/aristotle/graph_test.clj
@@ -9,6 +9,7 @@
 
 (reg/prefix 'foaf "http://xmlns.com/foaf/0.1/")
 (reg/prefix 'test "http://example.com/test/")
+(reg/prefix 'arachne "http://arachne-framework.org/#")
 
 (deftest nested-card-many
   (let [data [{:rdf/about :test/jane

--- a/test/arachne/aristotle/inference_test.clj
+++ b/test/arachne/aristotle/inference_test.clj
@@ -4,7 +4,6 @@
             [arachne.aristotle.registry :as reg]
             [arachne.aristotle.inference :as inf]
             [arachne.aristotle.query :as q]
-            [arachne.aristotle :as ar]
             [clojure.java.io :as io]))
 
 (reg/prefix 'daml "http://www.daml.org/2001/03/daml+oil#")

--- a/test/arachne/aristotle/query_test.clj
+++ b/test/arachne/aristotle/query_test.clj
@@ -1,11 +1,9 @@
 (ns arachne.aristotle.query-test
   (:require [clojure.test :refer :all]
             [arachne.aristotle.registry :as reg]
-            [arachne.aristotle.graph :as graph]
             [arachne.aristotle.query :as q]
             [arachne.aristotle :as aa]
-            [clojure.java.io :as io]
-            [clojure.walk :as w]))
+            [clojure.java.io :as io]))
 
 (reg/prefix 'foaf "http://xmlns.com/foaf/0.1/")
 (reg/prefix 'socrata "http://www.socrata.com/rdf/terms#")
@@ -230,13 +228,13 @@
                 first
                 ::name))))
 
-    (testing "limited recursion"
-      (is (= ::thom
-             (->> (q/pull pull-graph ::luke [::name {::friends '2}])
-                  ::friends
-                  (filter #(= "Jim" (::name %)))
-                  first
-                  ::friends
-                  first
-                  ::friends
-                  first)))))
+  (testing "limited recursion"
+    (is (= ::thom
+           (->> (q/pull pull-graph ::luke [::name {::friends '2}])
+                ::friends
+                (filter #(= "Jim" (::name %)))
+                first
+                ::friends
+                first
+                ::friends
+                first)))))

--- a/test/arachne/aristotle/reification_test.clj
+++ b/test/arachne/aristotle/reification_test.clj
@@ -2,10 +2,7 @@
   (:require [clojure.test :refer :all]
             [arachne.aristotle.registry :as reg]
             [arachne.aristotle.graph :as graph]
-            [arachne.aristotle.query :as q]
-            [arachne.aristotle :as aa]
-            [clojure.java.io :as io]
-            [clojure.walk :as w]))
+            [arachne.aristotle :as aa]))
 
 (reg/prefix 'foaf "http://xmlns.com/foaf/0.1/")
 
@@ -25,12 +22,12 @@
   (import '[java.util UUID])
 
   (def entities (vec (repeatedly 5000 (fn []
-                                         (str "<http://example.com/" (UUID/randomUUID) ">")
-                                         ))))
+                                         (str "<http://example.com/" (UUID/randomUUID) ">")))))
+
 
   (def properties (vec (repeatedly 500 (fn []
-                                           (str "<http://example.com/p/" (UUID/randomUUID) ">")
-                                         ))))
+                                           (str "<http://example.com/p/" (UUID/randomUUID) ">")))))
+
 
   (defn rand-triple
     []
@@ -44,12 +41,12 @@
   (time
    (let [g (aa/add (aa/graph :jena-mini) (repeatedly n rand-triple))
          g (graph/reify g "<http://example.com/graph>" (str (UUID/randomUUID)))]
-     (def the-g g)
-     ))
+     (def the-g g)))
+
 
   (def the-g nil)
 
-  (time (count (graph/triples the-g)))
+  (time (count (graph/triples the-g))))
 
   ;; Results: 100k triples (before reification) in a :jena-mini graph
   ;; cost about 1.1G of heap.
@@ -57,5 +54,5 @@
   ;; :simple is much cheaper, can fit about 1M
   ;; triples (before reification) in a 2GB data structure.
 
-  )
+
 

--- a/test/arachne/aristotle/validation_test.clj
+++ b/test/arachne/aristotle/validation_test.clj
@@ -2,7 +2,6 @@
   (:require [clojure.test :refer :all]
             [arachne.aristotle :as aa]
             [arachne.aristotle.registry :as reg]
-            [arachne.aristotle.query :as q]
             [arachne.aristotle.validation :as v]
             [clojure.java.io :as io]))
 
@@ -113,8 +112,8 @@
                                             :owl/differentFrom [:arachne/sara :arachne/jeff]}
                                            {:rdf/about :arachne/sara
                                             :arachne/name "Sarah"
-                                            :owl/differentFrom [:arachne/jim :arachne/jeff]
-                                            }}}])]
+                                            :owl/differentFrom [:arachne/jim :arachne/jeff]}}}])]
+
         (let [errors (v/validate g)]
           ;; The reasoner doesn't support this currently and there isn't a
           ;; great way to write a query, so we'll do without


### PR DESCRIPTION
The first commit just makes sure the existing tests all run. AFAIK the only real issue was a missing reg/prefix call. Other than that, I've just removed unused required namespaces in the test namespaces and formatted the code ever so slightly.

...

The second commit updates the version of Apache Jena used in Aristotle from version 3.x to the most recently released version: 4.5.

Other than the fact that it's nice to track Jena's current development directly, this also re-establishes compatibility with [igraph-jena](https://github.com/ont-app/igraph-jena).

I've also updated the other dependencies to their most recent version and took the liberty of doing some minor reformatting in the compiler ns (my parinfer broke due to whitespace inconsistencies) + vertically aligning the `expr-class` since I feel it becomes a lot more readable this way.