### PR TITLE
Fixes #14 - undo coercions of int and float

### DIFF
--- a/src/arachne/aristotle/graph.clj
+++ b/src/arachne/aristotle/graph.clj
@@ -99,13 +99,13 @@
     (NodeFactory/createLiteralByValue obj XSDDatatype/XSDlong))
   Integer
   (node [obj]
-    (NodeFactory/createLiteralByValue obj XSDDatatype/XSDlong))
+    (NodeFactory/createLiteralByValue obj XSDDatatype/XSDinteger))
   Double
   (node [obj]
     (NodeFactory/createLiteralByValue obj XSDDatatype/XSDdouble))
   Float
   (node [obj]
-    (NodeFactory/createLiteralByValue obj XSDDatatype/XSDdouble))
+    (NodeFactory/createLiteralByValue obj XSDDatatype/XSDfloat))
   Boolean
   (node [obj]
     (NodeFactory/createLiteralByValue obj XSDDatatype/XSDboolean))


### PR DESCRIPTION
Pretty simple change and everything seems to still work?

... at least on my machine I haven't run into any issues yet and this cleans up the .ttl export of e.g. floating point values, since they are now represented as literals rather than XSD-encoded strings.