### PR TITLE
Fixed spec for sort conditions.

### DIFF
--- a/src/arachne/aristotle/query/spec.clj
+++ b/src/arachne/aristotle/query/spec.clj
@@ -70,7 +70,7 @@
 
 (defd ::sort-conditions
   "A list of alternating expresion/direction pairs."
-  (s/cat :pairs (s/+ (s/cat :expr ::expr :direction #{:asc :desc}))))
+  (s/spec (s/cat :pairs (s/+ (s/cat :expr ::expr :direction #{:asc :desc})))))
 
 (defd ::quad
   "Quad represented as a 4-tuple"

--- a/test/arachne/aristotle/query_test.clj
+++ b/test/arachne/aristotle/query_test.clj
@@ -34,7 +34,19 @@
                   '[:bgp
                     [?e :ds/zip_code "90001"]
                     [?e :ds/total_population ?pop]])]
-    (is (= "57110" (get (first results) '?pop)))))
+    (is (= "57110" (get (first results) '?pop))))
+  (let [results (q/run test-graph
+                  '[:top-n 10 [(:xsd/integer ?population) :desc]
+                    [:bgp
+                     [?district :ds/total_population ?population]]])]
+    (is (= (count results) 10))
+    (is (= "<http://data.lacity.org/resource/zzzz-zzzz/132>" (get (first results) '?district))))
+  (let [results (q/run test-graph
+                  '[:order [(:xsd/integer ?population) :asc]
+                    [:bgp
+                     [?district :ds/total_population ?population]]])]
+    (is (= "0" (get (first results) '?population)))
+    (is (= "105549" (get (last results) '?population)))))
 
 (deftest functions+filters
   (is (= #{["90650"]}


### PR DESCRIPTION
`arachne.aristotle.query.compiler/op` expects queries to generally have at most three arguments. For
this to be true with `:top-n` and `:order` queries, the sort conditions need to be packed inside a
list.

With the old spec, the sort conditions were not nested, and thus `op` received the sort condition
keyword as `a2` and the direction keyword as `amore`, with the query appended.
