### PR TITLE
Upgrade Clojure to 1.12.0 and Jena to 5.3.0, refactor deprecated APIs

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,6 +1,6 @@
 {:paths   ["src"]
- :deps    {org.clojure/clojure              {:mvn/version "1.11.1"}
-           org.apache.jena/apache-jena-libs {:mvn/version "4.5.0"
+ :deps    {org.clojure/clojure              {:mvn/version "1.12.0"}
+           org.apache.jena/apache-jena-libs {:mvn/version "5.3.0"
                                              :extension   "pom"}
            ont-app/vocabulary               {:mvn/version "0.1.7"}
 

--- a/src/arachne/aristotle.clj
+++ b/src/arachne/aristotle.clj
@@ -7,7 +7,7 @@
             [arachne.aristotle.rdf-edn]
             [clojure.java.io :as io])
   (:import [org.apache.jena.reasoner.rulesys GenericRuleReasoner]
-           [org.apache.jena.graph Factory Graph GraphUtil]
+           [org.apache.jena.graph GraphMemFactory Graph GraphUtil]
            [org.apache.jena.riot RDFDataMgr]
            [org.apache.jena.riot Lang]
            [java.net URL]
@@ -30,7 +30,7 @@
 
 (defmethod graph :simple
   [_]
-  (Factory/createGraphMem))
+  (GraphMemFactory/createGraphMem))
 
 (defmethod graph :jena-mini
   [_]
@@ -44,7 +44,7 @@
   (let [reasoner (GenericRuleReasoner. initial-rules)]
      (.setOWLTranslation reasoner true)
      (.setTransitiveClosureCaching reasoner true)
-     (.bind reasoner (Factory/createGraphMem))))
+     (.bind reasoner (GraphMemFactory/createGraphMem))))
 
 (defn add
   "Add the given data to a graph, returning the graph. Data must satisfy
@@ -80,7 +80,6 @@
 
 (def formats {:csv Lang/CSV
               :jsonld Lang/JSONLD
-              :jsonld10 Lang/JSONLD10
               :jsonld11 Lang/JSONLD11
               :n3 Lang/N3
               :nquads Lang/NQUADS

--- a/src/arachne/aristotle/graph.clj
+++ b/src/arachne/aristotle/graph.clj
@@ -8,7 +8,7 @@
            [ont_app.vocabulary.lstr LangStr]
            [java.net URL URI]
            [java.util GregorianCalendar Calendar Date Map Collection List]
-           [org.apache.jena.graph Node NodeFactory Triple GraphUtil Node_URI Node_Literal Node_Variable Node_Blank Factory Graph]
+           [org.apache.jena.graph Node NodeFactory Triple GraphUtil Node_URI Node_Literal Node_Variable Node_Blank Graph]
            [org.apache.jena.datatypes.xsd XSDDatatype XSDDateTime]
            [javax.xml.bind DatatypeConverter]
            [org.apache.jena.riot RDFDataMgr]
@@ -93,7 +93,7 @@
       (NodeFactory/createLiteralByValue obj XSDDatatype/XSDstring)))
   LangStr
   (node [obj]
-    (NodeFactory/createLiteralByValue (str obj) (lang obj) XSDDatatype/XSDstring))
+    (NodeFactory/createLiteral (str obj) (lang obj) XSDDatatype/XSDstring))
   Long
   (node [obj]
     (NodeFactory/createLiteralByValue obj XSDDatatype/XSDlong))
@@ -165,7 +165,7 @@
   (data [n] (symbol (str "?" (.getName n))))
 
   Node_Blank
-  (data [n] (symbol (str "_" (.getLabelString (.getBlankNodeId n)))))
+  (data [n] (symbol (str "_" (.getBlankNodeLabel n))))
 
   Graph
   (data [g] (graph->clj g)))
@@ -271,7 +271,7 @@
 
   Graph
   (triples [^Graph g]
-    (.toSet (.find g (Triple. (node '?s) (node '?p) (node '?o))))))
+    (.toSet (.find g (Triple/create (node '?s) (node '?p) (node '?o))))))
 
 (defn reify
   "Given a graph, a property and an object, add reification triples to

--- a/src/arachne/aristotle/query/compiler.clj
+++ b/src/arachne/aristotle/query/compiler.clj
@@ -29,12 +29,12 @@
                   (cond
                     (instance? Node_Variable node) (Var/alloc ^Node_Variable node)
                     (instance? Node_Blank node)
-                    (let [id (str (.getBlankNodeId ^Node_Blank node))
+                    (let [id     (.getBlankNodeLabel ^Node_Blank node)
                           bnodes (swap! bnodes update-bnodes id)]
                       (bnodes id))
                     :else node))]
     (for [^Triple triple triples]
-      (Triple.
+      (Triple/create
         (replace (.getSubject triple))
         (replace (.getPredicate triple))
         (replace (.getObject triple))))))
@@ -150,7 +150,10 @@
     :extend (OpExtend/create (op a2) (var-expr-list a1))
     :graph (OpGraph. (graph/node a1) (op a2))
     :group (OpGroup/create (op (first amore))
-                           (VarExprList. ^List (var-seq a1))
+                           (reduce (fn [^VarExprList o v]
+                                     (doto o
+                                       (.add v)))
+                                   (VarExprList.) (var-seq a1))
                            (var-aggr-list a2))
     :join (OpJoin/create (op a1) (op a2))
     :label (OpLabel/create a1 (op a2))
@@ -286,4 +289,3 @@
   (require 'arachne.aristotle.query.spec)
   (s/conform :arachne.aristotle.query.spec/expr '(< 105000 (:xsd/integer ?pop)))
   #_.)
-


### PR DESCRIPTION
- Migrate Apache Jena from 4.5.0 to 5.3.0, addressing breaking changes:
  - Replace deprecated `Factory/createGraphMem` with `GraphMemFactory/createGraphMem`
  - Use updated `NodeFactory/createLiteral` for LangStr handling
  - Adopt `Triple/create` instead of direct constructor calls
  - Update blank node ID handling via `.getBlankNodeLabel`
  - Adjust `OpGroup` construction with explicit VarExprList population
- Remove deprecated JSON-LD 1.0 format support
- Ensure compatibility with Jena 5.x query compiler APIs